### PR TITLE
Fix: remove conflict resolution merges

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,17 +12,17 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rake (10.5.0)
+    rake (12.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 2.0.1)
-  minitest (~> 5.0)
+  minitest (~> 5.11.3)
   pr_changelog!
   pry (~> 0.12.2)
-  rake (~> 10.0)
+  rake (~> 12.3.2)
 
 BUNDLED WITH
    2.0.1

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Will produce something like:
 
 - #64: Improvement: visual refinements for canvas 2.0
 - #65: Internal: add formatting rules for xml files
-- #63: Feature: Add Footer story
-- #57: Improvement: Memory performance tweaks
+- #63: Feature: add Footer story
+- #57: Improvement: memory performance tweaks
 - #61: Feature: shake the phone to send feedback email
 - #62: Improvement: visual polishing for top stories
 - #60: Internal: setup hockeyapp for crash reporting

--- a/lib/pr_changelog.rb
+++ b/lib/pr_changelog.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require 'pr_changelog/version'
+require 'pr_changelog/extensions/string'
 require 'pr_changelog/cli'
 require 'pr_changelog/git_proxy'
+require 'pr_changelog/tag'
+require 'pr_changelog/change_line'
+require 'pr_changelog/grouped_changes'
 require 'pr_changelog/not_released_changes'
 
 # Main module

--- a/lib/pr_changelog/change_line.rb
+++ b/lib/pr_changelog/change_line.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # Represents a single change entry in the changelog
+  class ChangeLine
+    attr_reader :pr_number, :tag, :title
+
+    def initialize(pr_number, tag, title)
+      @pr_number = pr_number
+      @tag = tag
+      @title = title
+    end
+
+    def to_s
+      if tag.nil?
+        "- #{pr_number}: #{title.first_lowercase}"
+      else
+        "- #{pr_number}: #{tag}: #{title.first_lowercase}"
+      end
+    end
+
+    def formatted_title
+      title.first_uppercase
+    end
+
+    def emojified_for(tag_object)
+      "- #{pr_number}: #{tag_object.emoji} #{formatted_title}"
+    end
+  end
+end

--- a/lib/pr_changelog/extensions/string.rb
+++ b/lib/pr_changelog/extensions/string.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Some useful extensions on string
+class String
+  def first_uppercase
+    return self unless length > 2
+
+    "#{self[0].upcase}#{self[1, length]}"
+  end
+
+  def first_lowercase
+    return self unless length > 2
+
+    "#{self[0].downcase}#{self[1, length]}"
+  end
+end

--- a/lib/pr_changelog/git_proxy.rb
+++ b/lib/pr_changelog/git_proxy.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 module PrChangelog
   class GitProxy
-    LOG_FORMAT = '- %cn: %s%n%w(80, 2, 2)%b'.freeze
+    LOG_FORMAT = '- %cn: %s%n%w(80, 2, 2)%b'
 
     def merge_commits_between(base_ref, current_ref)
       `git log --merges #{base_ref}..#{current_ref} --format='#{LOG_FORMAT}'`
     end
   end
 end
-

--- a/lib/pr_changelog/git_proxy.rb
+++ b/lib/pr_changelog/git_proxy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module PrChangelog
+  # A boundary class between git and the rest of the gem
   class GitProxy
     LOG_FORMAT = '- %cn: %s%n%w(80, 2, 2)%b'
 

--- a/lib/pr_changelog/grouped_changes.rb
+++ b/lib/pr_changelog/grouped_changes.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # A class to group change lines by tag
+  class GroupedChanges
+    attr_reader :changes, :tags
+
+    def initialize(changes, tags)
+      @changes = changes
+      @tags = tags
+    end
+
+    def to_s
+      new_hash = {}
+      grouped_changes.each do |tag, change_lines|
+        new_key = tag.formatted_title
+        new_hash[new_key] = change_lines.map do |change_line|
+          change_line.emojified_for(tag)
+        end
+      end
+
+      new_hash.reduce('') do |string, pair|
+        tag   = pair[0]
+        lines = pair[1].map { |l| "  #{l}" }.join("\n")
+        string + "#{tag}\n#{lines}\n\n"
+      end.strip.chomp
+    end
+
+    private
+
+    def grouped_changes
+      @grouped_changes ||= changes.group_by do |change_line|
+        tags[change_line&.tag&.downcase] || tags['unclassified']
+      end.sort do |first_group, second_group|
+        first_group[0].sort_index <=> second_group[0].sort_index
+      end
+    end
+  end
+end

--- a/lib/pr_changelog/not_released_changes.rb
+++ b/lib/pr_changelog/not_released_changes.rb
@@ -97,8 +97,8 @@ module PrChangelog
       merge_commits_not_merged_into_base_ref
         .split('- ')
         .reject(&:empty?)
-        .reject { |line| line.match(MERGE_BRANCH_COMMIT_FORMAT) }
         .map { |e| e.split("\n") }
+        .select { |pair| pair.count == 2 }
     end
 
     def format_merge_commit(github_commit_title, commit_title)

--- a/lib/pr_changelog/not_released_changes.rb
+++ b/lib/pr_changelog/not_released_changes.rb
@@ -4,9 +4,15 @@ module PrChangelog
   # Calculates a list of not released changes from `base_ref` to `current_ref`
   # those changes consist of the merged pull-request title
   class NotReleasedChanges
-    GITHUB_MERGE_COMMIT_FORMAT = /Merge pull request (?<pr_number>#\d+) .*/.freeze
-    MERGE_BRANCH_COMMIT_FORMAT = /(Merge branch '.*'\s?(into|of)? .*)|(Merge .* branch .*)/.freeze
-    PARSED_MERGE_COMMIT_FORMAT = /^- #(?<pr_number>\d+):\s+(?<tag>[^\s]+):\s*(?<title>.*)$/.freeze
+    MERGE_COMMIT_FORMAT = /Merge pull request (?<pr_number>#\d+) .*/.freeze
+    TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
+    EMOJI_TAGS = {
+      'feature' => Tag.new('⭐️', 'New features', 0),
+      'fix' => Tag.new('🐛', 'Fixes', 1),
+      'improvement' => Tag.new('💎', 'Improvements', 2),
+      'internal' => Tag.new('👨‍💻', 'Internal', 4),
+      'unclassified' => Tag.new('❓', 'Unclassified', 5)
+    }.freeze
 
     attr_reader :base_ref, :current_ref, :git_proxy
 
@@ -16,81 +22,28 @@ module PrChangelog
       @git_proxy   = git_proxy
     end
 
-    Tag = Struct.new(:emoji, :title, :sort)
-
-    EMOJI_TAGS = {
-      'feature' => Tag.new('⭐️', 'New features', 0),
-      'fix' => Tag.new('🐛', 'Fixes', 1),
-      'improvement' => Tag.new('💎', 'Improvements', 2),
-      'internal' => Tag.new('👨‍💻', 'Internal', 4),
-      'unclassified' => Tag.new('❓', 'Unclassified', 5)
-    }.freeze
-
     def formatted_changelog
-      if formatted_change_list.count.positive?
-        formatted_change_list.join("\n")
+      if parsed_change_list.count.positive?
+        parsed_change_list.map(&:to_s).join("\n")
       else
         "There are no changes since #{base_ref} to #{current_ref}"
       end
     end
 
     def grouped_formatted_changelog
-      changes = formatted_change_list
-      if changes.count.positive?
-
-        grouped_changes = changes.group_by do |change_line|
-          EMOJI_TAGS[tag_from(change_line)] || EMOJI_TAGS['unclassified']
-        end
-
-        sorted_hash = grouped_changes.sort do |first_pair, second_pair|
-          first_pair[0].sort <=> second_pair[0].sort
-        end
-
-        new_hash = {}
-        sorted_hash.each do |tag, change_lines|
-          new_key = "[#{tag.title}]"
-          new_hash[new_key] = change_lines.map do |change_line|
-            emojify_tag_for(change_line)
-          end
-        end
-
-        new_hash.reduce('') do |string, pair|
-          tag   = pair[0]
-          lines = pair[1].map { |l| "  #{l}" }.join("\n")
-          string + "#{tag}\n#{lines}\n\n"
-        end.strip.chomp
+      if parsed_change_list.count.positive?
+        GroupedChanges.new(parsed_change_list, EMOJI_TAGS).to_s
       else
         "There are no changes since #{base_ref} to #{current_ref}"
       end
     end
 
-    def formatted_change_list
-      parsed_merge_commits.map do |pair|
-        format_merge_commit(pair.first, pair.last)
-      end
-    end
-
     private
 
-    def first_uppercase(line)
-      return line unless line.length > 2
-
-      "#{line[0].upcase}#{line[1, line.length]}"
-    end
-
-    def emojify_tag_for(change_line)
-      match = change_line.match(PARSED_MERGE_COMMIT_FORMAT)
-      return change_line unless match
-
-      emoji_tag = EMOJI_TAGS[match[:tag].downcase].emoji || '❓'
-      "- ##{match[:pr_number]}: #{emoji_tag} #{first_uppercase(match[:title])}"
-    end
-
-    def tag_from(merge_commit)
-      match = merge_commit.match(PARSED_MERGE_COMMIT_FORMAT)
-      return nil unless match
-
-      match[:tag].downcase
+    def parsed_change_list
+      @parsed_change_list ||= parsed_merge_commits.map do |pair|
+        format_merge_commit(pair.first, pair.last)
+      end
     end
 
     def parsed_merge_commits
@@ -103,8 +56,13 @@ module PrChangelog
 
     def format_merge_commit(github_commit_title, commit_title)
       pr_number = pull_request_number_for(github_commit_title)
-
-      "- #{pr_number}: #{commit_title.strip}"
+      commit_title.strip!
+      match = commit_title.match(TAGGED_TITLE)
+      if match
+        ChangeLine.new(pr_number, match[:tag], match[:title])
+      else
+        ChangeLine.new(pr_number, nil, commit_title)
+      end
     end
 
     def merge_commits_not_merged_into_base_ref
@@ -112,7 +70,7 @@ module PrChangelog
     end
 
     def pull_request_number_for(github_commit_title)
-      md = github_commit_title.match(GITHUB_MERGE_COMMIT_FORMAT)
+      md = github_commit_title.match(MERGE_COMMIT_FORMAT)
       md[:pr_number] if md
     end
   end

--- a/lib/pr_changelog/tag.rb
+++ b/lib/pr_changelog/tag.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # A way to classify particular change lines
+  class Tag
+    attr_reader :emoji, :title, :sort_index
+
+    def initialize(emoji, title, sort_index)
+      @emoji = emoji
+      @title = title
+      @sort_index = sort_index
+    end
+
+    def formatted_title
+      "[#{title}]"
+    end
+  end
+end

--- a/pr_changelog.gemspec
+++ b/pr_changelog.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 2.0.1'
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest', '~> 5.11.3'
   spec.add_development_dependency 'pry', '~> 0.12.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3.2'
 end

--- a/test/not_released_changes_test.rb
+++ b/test/not_released_changes_test.rb
@@ -38,4 +38,3 @@ class NotReleasedChangesTest < Minitest::Test
     File.readlines(file_name).join('').chomp
   end
 end
-

--- a/test/sample_data/plain_format.txt
+++ b/test/sample_data/plain_format.txt
@@ -1,28 +1,28 @@
-- #86: Internal: Update to android studio 3.3
-- #87: Improvement: Update system notification channels from backend
-- #85: Feature: Notification settings UI and sync with backend and system settings
+- #86: Internal: update to android studio 3.3
+- #87: Improvement: update system notification channels from backend
+- #85: Feature: notification settings UI and sync with backend and system settings
 - #84: Improvement: allow cards format to be used not only on the weekly summary
 - #82: Internal: fix the notification keys
 - #81: Fix: only present feedback email dialog if app is on foreground
-- #80: Improvement: Add app version number to the placeholder feedback email
+- #80: Improvement: add app version number to the placeholder feedback email
 - #79: Fix: dimensions to fetch the avatar images
 - #78: Fix: update the feedback email to peil-android@schibsted.com
-- #77: Improvement: Add support for opening external links in Daily Summary
+- #77: Improvement: add support for opening external links in Daily Summary
 - #76: Internal: use beta track for releasing the app
 - #75: Fix: update feedback email
-- #70: Improvement: Daily Summary polish
+- #70: Improvement: daily Summary polish
 - #68: Fix: allow opening canvas stories from the weekly summary
 - #74: Improvement: remove card about push notifications in Daily Summary
 - #73: Improvement: remove unnecessary BodyText style
 - #72: Internal: update the feedback email
 - #71: Internal: send `peil-app-version` on every request to the backend
 - #69: Improvement: use open-sans as base font for text
-- #67: Fix: Swipe on text in Daily Summary
+- #67: Fix: swipe on text in Daily Summary
 - #66: Internal: fix code style for xml files
 - #64: Improvement: visual refinements for canvas 2.0
 - #65: Internal: add formatting rules for xml files
-- #63: Feature: Add Footer story
-- #57: Improvement: Memory performance tweaks
+- #63: Feature: add Footer story
+- #57: Improvement: memory performance tweaks
 - #61: Feature: shake the phone to send feedback email
 - #62: Improvement: visual polishing for top stories
 - #60: Internal: setup hockeyapp for crash reporting

--- a/test/sample_data/raw_log.txt
+++ b/test/sample_data/raw_log.txt
@@ -20,6 +20,8 @@
   Improvement: Add support for opening external links in Daily Summary
 - GitHub Enterprise: Merge pull request #76 from schibsted_repo/internal/use-the-beta-track-to-publish-the-app
   Internal: use beta track for releasing the app
+- andrey-volobuev: Resolved merge conflicts. Fixed schedule update bug for collapsed sections
+
 - GitHub Enterprise: Merge pull request #75 from schibsted_repo/fix/update-feedback-email
   Fix: update feedback email
 - GitHub Enterprise: Merge pull request #70 from schibsted_repo/improvement/daily-summary-polish
@@ -36,6 +38,7 @@
   Internal: update the feedback email
 - GitHub Enterprise: Merge pull request #71 from schibsted_repo/internal/send-app-version-to-the-backend
   Internal: send `peil-app-version` on every request to the backend
+- andrey-volobuev: Resolved conflicts
 - GitHub Enterprise: Merge pull request #69 from schibsted_repo/improvment/use-open-sans-as-base-font
   Improvement: use open-sans as base font for text
 - GitHub Enterprise: Merge pull request #67 from schibsted_repo/fix/swipe-cards-daily-summary


### PR DESCRIPTION
there were some lines that we should avoid like:

> - andrey-volobuev: Resolved merge conflicts. Fixed schedule update bug for collapsed sections

now we filter in a more efficient way the distinction between github merge commits and other kinds of merge commits