### PR TITLE
Fix: correct the default format for the changelog

### DIFF
--- a/lib/pr_changelog/cli.rb
+++ b/lib/pr_changelog/cli.rb
@@ -21,7 +21,7 @@ module PrChangelog
     attr_reader :format, :from_reference, :to_reference
 
     def initialize(args)
-      @format = 'pretty'
+      @format = 'plain'
       if args.include?('--format')
         next_index = args.index('--format') + 1
         @format = args.fetch(next_index)


### PR DESCRIPTION
Following \#4, I forgot to change the value of the actual default format