### PR TITLE
Improvement: add 'master' as default to reference

### DIFF
--- a/lib/pr_changelog/cli.rb
+++ b/lib/pr_changelog/cli.rb
@@ -37,6 +37,7 @@ module PrChangelog
       end
 
       @from_reference, @to_reference = args.last(2)
+      @to_reference ||= 'master'
 
       return if @from_reference && @to_reference
 


### PR DESCRIPTION
So you can run the script like:

```
pr_changelog v0.1.1
```

And it will compare the changes from v0.1.1 to master, which is a way to
get the _unreleased_ changes if `v0.1.1` is the last release