### PR TITLE
Internal: replace `throw` with `raise`

### DIFF
--- a/lib/pr_changelog/cli.rb
+++ b/lib/pr_changelog/cli.rb
@@ -27,7 +27,7 @@ module PrChangelog
     attr_reader :format, :from_reference, :to_reference
 
     def initialize(args)
-      throw HelpWanted if args.include?('--help') || args.include?('-h')
+      raise HelpWanted.new if args.include?('--help') || args.include?('-h')
 
       @format = PrChangelog.config.default_format
       if args.include?('--format')
@@ -41,7 +41,7 @@ module PrChangelog
 
       return if @from_reference && @to_reference
 
-      throw InvalidInputs.new
+      raise InvalidInputs.new
     end
 
     def run


### PR DESCRIPTION
> catch/throw are not the same as raise/rescue. catch/throw allows you
> to quickly exit blocks back to a point where a catch is defined for a
> specific symbol, raise rescue is the real exception handling stuff
> involving the Exception object.

Although the way I'm usign exceptions here is not entirely correct,
since in some instances I am trying to avoid unnecessary computation,
like when passing `-h`. I will go with only `raise` as then I am more
consistent on how to bubble up those exceptions.

reference: https://stackoverflow.com/a/51037/611678