### PR TITLE
Feature: changelogs from "squash merge" pull requests

### DIFF
--- a/lib/pr_changelog.rb
+++ b/lib/pr_changelog.rb
@@ -10,8 +10,10 @@ require 'pr_changelog/git_proxy'
 require 'pr_changelog/tag'
 require 'pr_changelog/change_line'
 require 'pr_changelog/grouped_changes'
+require 'pr_changelog/base_commit_strategy'
+require 'pr_changelog/merge_commit_strategy'
+require 'pr_changelog/squash_commit_strategy'
 require 'pr_changelog/not_released_changes'
-require 'pr_changelog/not_released_squash_changes'
 
 # Main module
 module PrChangelog

--- a/lib/pr_changelog.rb
+++ b/lib/pr_changelog.rb
@@ -11,6 +11,7 @@ require 'pr_changelog/tag'
 require 'pr_changelog/change_line'
 require 'pr_changelog/grouped_changes'
 require 'pr_changelog/not_released_changes'
+require 'pr_changelog/not_released_squash_changes'
 
 # Main module
 module PrChangelog

--- a/lib/pr_changelog/base_commit_strategy.rb
+++ b/lib/pr_changelog/base_commit_strategy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # Todo
+  class BaseCommitStrategy
+    def parsed_commits
+      raise 'Not implemented'
+    end
+
+    def format_commit(_commit_line)
+      raise 'Not implemented'
+    end
+  end
+end

--- a/lib/pr_changelog/base_commit_strategy.rb
+++ b/lib/pr_changelog/base_commit_strategy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PrChangelog
-  # Todo
+  # A "protocol"-like base class for the extracting the change commit strategies
   class BaseCommitStrategy
     def parsed_commits
       raise 'Not implemented'

--- a/lib/pr_changelog/change_line.rb
+++ b/lib/pr_changelog/change_line.rb
@@ -13,7 +13,7 @@ module PrChangelog
 
     def to_s
       if tag.nil?
-        "- #{pr_number}: #{title.first_lowercase}"
+        "- #{pr_number}: #{formatted_title}"
       else
         "- #{pr_number}: #{tag}: #{title.first_lowercase}"
       end

--- a/lib/pr_changelog/config.rb
+++ b/lib/pr_changelog/config.rb
@@ -7,6 +7,7 @@ module PrChangelog
   class Config
     DEFAULTS = {
       format: 'plain',
+      strategy: 'merge',
       tags: [
         {
           prefix: 'feature',
@@ -47,6 +48,10 @@ module PrChangelog
 
     def default_format
       loaded_data[:format] || DEFAULTS[:format]
+    end
+
+    def default_strategy
+      loaded_data[:strategy] || DEFAULTS[:strategy]
     end
 
     def tags

--- a/lib/pr_changelog/git_proxy.rb
+++ b/lib/pr_changelog/git_proxy.rb
@@ -5,6 +5,10 @@ module PrChangelog
   class GitProxy
     LOG_FORMAT = '- %cn: %s%n%w(80, 2, 2)%b'
 
+    def commits_between(base_ref, current_ref)
+      `git log #{base_ref}..#{current_ref} --format='#{LOG_FORMAT}'`
+    end
+
     def merge_commits_between(base_ref, current_ref)
       `git log --merges #{base_ref}..#{current_ref} --format='#{LOG_FORMAT}'`
     end

--- a/lib/pr_changelog/merge_commit_strategy.rb
+++ b/lib/pr_changelog/merge_commit_strategy.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module PrChangelog
-  # Todo
+  # A strategy that given two references will return the filtered commit changes
+  # based on the merge commits
   class MergeCommitStrategy < BaseCommitStrategy
     MERGE_COMMIT_FORMAT = /Merge pull request (?<pr_number>#\d+) .*/.freeze
     TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze

--- a/lib/pr_changelog/merge_commit_strategy.rb
+++ b/lib/pr_changelog/merge_commit_strategy.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # Todo
+  class MergeCommitStrategy < BaseCommitStrategy
+    MERGE_COMMIT_FORMAT = /Merge pull request (?<pr_number>#\d+) .*/.freeze
+    TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
+
+    attr_reader :base_ref, :current_ref, :git_proxy
+
+    def initialize(base_ref, current_ref, git_proxy = GitProxy.new)
+      @base_ref    = base_ref
+      @current_ref = current_ref
+      @git_proxy   = git_proxy
+    end
+
+    def parsed_commits
+      merge_commits_not_merged_into_base_ref
+        .split('- ')
+        .reject(&:empty?)
+        .map { |e| e.split("\n") }
+        .select { |pair| pair.count == 2 }
+    end
+
+    def format_commit(commit_info)
+      github_commit_title = commit_info.first
+      commit_title = commit_info.last
+
+      pr_number = pull_request_number_for(github_commit_title)
+      commit_title.strip!
+      match = commit_title.match(TAGGED_TITLE)
+      if match
+        ChangeLine.new(pr_number, match[:tag], match[:title])
+      else
+        ChangeLine.new(pr_number, nil, commit_title)
+      end
+    end
+
+    private
+
+    def merge_commits_not_merged_into_base_ref
+      git_proxy.merge_commits_between(base_ref, current_ref)
+    end
+
+    def pull_request_number_for(github_commit_title)
+      md = github_commit_title.match(MERGE_COMMIT_FORMAT)
+      md[:pr_number] if md
+    end
+  end
+end

--- a/lib/pr_changelog/not_released_changes.rb
+++ b/lib/pr_changelog/not_released_changes.rb
@@ -4,15 +4,10 @@ module PrChangelog
   # Calculates a list of not released changes from `base_ref` to `current_ref`
   # those changes consist of the merged pull-request title
   class NotReleasedChanges
-    MERGE_COMMIT_FORMAT = /Merge pull request (?<pr_number>#\d+) .*/.freeze
-    TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
+    attr_reader :commits_strategy
 
-    attr_reader :base_ref, :current_ref, :git_proxy
-
-    def initialize(base_ref, current_ref, git_proxy = GitProxy.new)
-      @base_ref    = base_ref
-      @current_ref = current_ref
-      @git_proxy   = git_proxy
+    def initialize(commits_strategy)
+      @commits_strategy = commits_strategy
     end
 
     def emoji_tags
@@ -48,37 +43,9 @@ module PrChangelog
     end
 
     def parsed_change_list
-      @parsed_change_list ||= parsed_merge_commits.map do |pair|
-        format_merge_commit(pair.first, pair.last)
+      @parsed_change_list ||= commits_strategy.parsed_commits.map do |commit_info|
+        commits_strategy.format_commit(commit_info)
       end
-    end
-
-    def parsed_merge_commits
-      merge_commits_not_merged_into_base_ref
-        .split('- ')
-        .reject(&:empty?)
-        .map { |e| e.split("\n") }
-        .select { |pair| pair.count == 2 }
-    end
-
-    def format_merge_commit(github_commit_title, commit_title)
-      pr_number = pull_request_number_for(github_commit_title)
-      commit_title.strip!
-      match = commit_title.match(TAGGED_TITLE)
-      if match
-        ChangeLine.new(pr_number, match[:tag], match[:title])
-      else
-        ChangeLine.new(pr_number, nil, commit_title)
-      end
-    end
-
-    def merge_commits_not_merged_into_base_ref
-      git_proxy.merge_commits_between(base_ref, current_ref)
-    end
-
-    def pull_request_number_for(github_commit_title)
-      md = github_commit_title.match(MERGE_COMMIT_FORMAT)
-      md[:pr_number] if md
     end
   end
 end

--- a/lib/pr_changelog/not_released_squash_changes.rb
+++ b/lib/pr_changelog/not_released_squash_changes.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module PrChangelog
+  # Calculates a list of not released changes from `base_ref` to `current_ref`
+  # those changes consist of the merged pull-request title
+  class NotReleasedSquashChanges
+    SQUASH_COMMIT_FORMAT = /^GitHub: (?<title>[^(]+) \((?<pr_number>#\d+)\)$/.freeze
+    TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
+
+    attr_reader :base_ref, :current_ref, :git_proxy
+
+    def initialize(base_ref, current_ref, git_proxy = GitProxy.new)
+      @base_ref    = base_ref
+      @current_ref = current_ref
+      @git_proxy   = git_proxy
+    end
+
+    def formatted_changelog
+      if parsed_change_list.count.positive?
+        parsed_change_list.map(&:to_s).join("\n")
+      else
+        no_changes_found
+      end
+    end
+
+    private
+
+    def no_changes_found
+      'No changes found'
+    end
+
+    def parsed_change_list
+      @parsed_change_list ||= parsed_commits.map do |commit_line|
+        format_commit(commit_line)
+      end
+    end
+
+    def parsed_commits
+      commits_not_merged_into_base_ref
+        .split('- ')
+        .reject(&:empty?)
+        .map { |e| e.split("\n") }
+        .map(&:first)
+        .select { |line| line.match(SQUASH_COMMIT_FORMAT) }
+    end
+
+    def format_commit(commit_line)
+      pr_number = pull_request_number_for(commit_line)
+      commit_title = pull_request_title_for(commit_line)
+      commit_title.strip!
+      # match = commit_title.match(TAGGED_TITLE)
+      # if match
+        # ChangeLine.new(pr_number, match[:tag], match[:title])
+      # else
+        ChangeLine.new(pr_number, nil, commit_title)
+      # end
+    end
+
+    def commits_not_merged_into_base_ref
+      git_proxy.commits_between(base_ref, current_ref)
+    end
+
+    def pull_request_number_for(github_commit_title)
+      md = github_commit_title.match(SQUASH_COMMIT_FORMAT)
+      md[:pr_number] if md
+    end
+
+    def pull_request_title_for(github_commit_title)
+      md = github_commit_title.match(SQUASH_COMMIT_FORMAT)
+      # require 'pry'; binding.pry
+      md[:title] if md
+    end
+  end
+end

--- a/lib/pr_changelog/releases.rb
+++ b/lib/pr_changelog/releases.rb
@@ -9,11 +9,22 @@ module PrChangelog
     end
 
     def last_release
-      git_proxy.git_tags_list.last
+      sorted_tags.last
     end
 
     def last_release_pair
-      git_proxy.git_tags_list.last(2)
+      sorted_tags.last(2)
+    end
+
+    private
+
+    def sorted_tags
+      git_proxy.git_tags_list.sort_by { |tag| tag_value(tag) }
+    end
+
+    def tag_value(tag)
+      components = tag.split('.')
+      components[0].to_i * 100_000 + components[1].to_i * 1_000 + components[2].to_i
     end
   end
 end

--- a/lib/pr_changelog/squash_commit_strategy.rb
+++ b/lib/pr_changelog/squash_commit_strategy.rb
@@ -6,7 +6,7 @@ module PrChangelog
   # squash commits
   class SquashCommitStrategy < BaseCommitStrategy
     SQUASH_COMMIT_FORMAT = /^GitHub( Enterprise)?: (?<title>.+) \((?<pr_number>#\d+)\)$/.freeze
-    TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
+    TAGGED_TITLE = /^(?<tag>[^:]+):\s*(?<title>.+)$/.freeze
 
     attr_reader :base_ref, :current_ref, :git_proxy
 
@@ -29,12 +29,12 @@ module PrChangelog
       pr_number = pull_request_number_for(commit_line)
       commit_title = pull_request_title_for(commit_line)
       commit_title.strip!
-      # match = commit_title.match(TAGGED_TITLE)
-      # if match
-        # ChangeLine.new(pr_number, match[:tag], match[:title])
-      # else
+      match = commit_title.match(TAGGED_TITLE)
+      if match
+        ChangeLine.new(pr_number, match[:tag], match[:title])
+      else
         ChangeLine.new(pr_number, nil, commit_title)
-      # end
+      end
     end
 
     private

--- a/lib/pr_changelog/squash_commit_strategy.rb
+++ b/lib/pr_changelog/squash_commit_strategy.rb
@@ -1,9 +1,9 @@
+
 # frozen_string_literal: true
 
 module PrChangelog
-  # Calculates a list of not released changes from `base_ref` to `current_ref`
-  # those changes consist of the merged pull-request title
-  class NotReleasedSquashChanges
+  # Todo
+  class SquashCommitStrategy < BaseCommitStrategy
     SQUASH_COMMIT_FORMAT = /^GitHub: (?<title>[^(]+) \((?<pr_number>#\d+)\)$/.freeze
     TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
 
@@ -13,26 +13,6 @@ module PrChangelog
       @base_ref    = base_ref
       @current_ref = current_ref
       @git_proxy   = git_proxy
-    end
-
-    def formatted_changelog
-      if parsed_change_list.count.positive?
-        parsed_change_list.map(&:to_s).join("\n")
-      else
-        no_changes_found
-      end
-    end
-
-    private
-
-    def no_changes_found
-      'No changes found'
-    end
-
-    def parsed_change_list
-      @parsed_change_list ||= parsed_commits.map do |commit_line|
-        format_commit(commit_line)
-      end
     end
 
     def parsed_commits
@@ -56,6 +36,8 @@ module PrChangelog
       # end
     end
 
+    private
+
     def commits_not_merged_into_base_ref
       git_proxy.commits_between(base_ref, current_ref)
     end
@@ -67,7 +49,6 @@ module PrChangelog
 
     def pull_request_title_for(github_commit_title)
       md = github_commit_title.match(SQUASH_COMMIT_FORMAT)
-      # require 'pry'; binding.pry
       md[:title] if md
     end
   end

--- a/lib/pr_changelog/squash_commit_strategy.rb
+++ b/lib/pr_changelog/squash_commit_strategy.rb
@@ -4,7 +4,7 @@
 module PrChangelog
   # Todo
   class SquashCommitStrategy < BaseCommitStrategy
-    SQUASH_COMMIT_FORMAT = /^GitHub: (?<title>[^(]+) \((?<pr_number>#\d+)\)$/.freeze
+    SQUASH_COMMIT_FORMAT = /^GitHub( Enterprise)?: (?<title>.+) \((?<pr_number>#\d+)\)$/.freeze
     TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze
 
     attr_reader :base_ref, :current_ref, :git_proxy

--- a/lib/pr_changelog/squash_commit_strategy.rb
+++ b/lib/pr_changelog/squash_commit_strategy.rb
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 module PrChangelog
-  # Todo
+  # A strategy to get the changes between the two references based on the
+  # squash commits
   class SquashCommitStrategy < BaseCommitStrategy
     SQUASH_COMMIT_FORMAT = /^GitHub( Enterprise)?: (?<title>.+) \((?<pr_number>#\d+)\)$/.freeze
     TAGGED_TITLE = /^(?<tag>.+):\s*(?<title>.+)$/.freeze

--- a/test/pr_changelog/not_released_changes_test.rb
+++ b/test/pr_changelog/not_released_changes_test.rb
@@ -9,11 +9,12 @@ class NotReleasedChangesTest < Minitest::Test
     end
   end
 
-  attr_reader :test_git, :changes
+  attr_reader :changes
 
   def setup
-    @test_git = TestGit.new
-    @changes = PrChangelog::NotReleasedChanges.new('0.3.0', '0.5.0', test_git)
+    test_git = TestGit.new
+    strategy = PrChangelog::MergeCommitStrategy.new('0.3.0', '0.5.0', test_git)
+    @changes = PrChangelog::NotReleasedChanges.new(strategy)
   end
 
   def test_plain_format

--- a/test/pr_changelog/not_released_squashed_changes_test.rb
+++ b/test/pr_changelog/not_released_squashed_changes_test.rb
@@ -21,8 +21,15 @@ class NotReleasedSquashedChangesTest < Minitest::Test
     sample_plain_changelog = lines_from_file(
       'test/sample_data/plain_format_squash.txt'
     )
-
     assert_equal sample_plain_changelog, changes.formatted_changelog
+  end
+
+  def test_pretty_format
+    sample_pretty_changelog = lines_from_file(
+      'test/sample_data/pretty_format_squash.txt'
+    )
+
+    assert_equal sample_pretty_changelog, changes.grouped_formatted_changelog
   end
 
   private

--- a/test/pr_changelog/not_released_squashed_changes_test.rb
+++ b/test/pr_changelog/not_released_squashed_changes_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class NotReleasedSquashedChangesTest < Minitest::Test
   class TestGit
-    def merge_commits_between(_from_ref, _to_ref)
+    def commits_between(_from_ref, _to_ref)
       File.readlines('test/sample_data/raw_squash_log.txt').join('').chomp
     end
   end
@@ -13,7 +13,7 @@ class NotReleasedSquashedChangesTest < Minitest::Test
 
   def setup
     @test_git = TestGit.new
-    @changes = PrChangelog::NotReleasedChanges.new('0.3.0', '0.5.0', test_git)
+    @changes = PrChangelog::NotReleasedSquashChanges.new('0.3.0', '0.5.0', test_git)
   end
 
   def test_plain_format

--- a/test/pr_changelog/not_released_squashed_changes_test.rb
+++ b/test/pr_changelog/not_released_squashed_changes_test.rb
@@ -9,11 +9,12 @@ class NotReleasedSquashedChangesTest < Minitest::Test
     end
   end
 
-  attr_reader :test_git, :changes
+  attr_reader :changes
 
   def setup
-    @test_git = TestGit.new
-    @changes = PrChangelog::NotReleasedSquashChanges.new('0.3.0', '0.5.0', test_git)
+    test_git = TestGit.new
+    strategy = PrChangelog::SquashCommitStrategy.new('0.3.0', '0.5.0', test_git)
+    @changes = PrChangelog::NotReleasedChanges.new(strategy)
   end
 
   def test_plain_format

--- a/test/pr_changelog/not_released_squashed_changes_test.rb
+++ b/test/pr_changelog/not_released_squashed_changes_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotReleasedSquashedChangesTest < Minitest::Test
+  class TestGit
+    def merge_commits_between(_from_ref, _to_ref)
+      File.readlines('test/sample_data/raw_squash_log.txt').join('').chomp
+    end
+  end
+
+  attr_reader :test_git, :changes
+
+  def setup
+    @test_git = TestGit.new
+    @changes = PrChangelog::NotReleasedChanges.new('0.3.0', '0.5.0', test_git)
+  end
+
+  def test_plain_format
+    sample_plain_changelog = lines_from_file(
+      'test/sample_data/plain_format_squash.txt'
+    )
+
+    assert_equal sample_plain_changelog, changes.formatted_changelog
+  end
+
+  private
+
+  def lines_from_file(file_name)
+    File.readlines(file_name).join('').chomp
+  end
+end

--- a/test/pr_changelog/releases_test.rb
+++ b/test/pr_changelog/releases_test.rb
@@ -7,7 +7,19 @@ class ReleasesTest < Minitest::Test
     attr_reader :expected_tags
 
     def initialize(expected_tags = nil)
-      @expected_tags = expected_tags || ['0.1.0', '0.2.1', '0.2.2', '0.3.0']
+      default_tags = [
+        '1.10.0',
+        '1.10.1',
+        '1.11.0',
+        '1.12.0',
+        '1.12.1',
+        '1.7.0',
+        '1.7.1',
+        '1.8.0',
+        '1.9.2',
+        '1.9.3'
+      ]
+      @expected_tags = expected_tags || default_tags
     end
 
     def git_tags_list
@@ -19,14 +31,14 @@ class ReleasesTest < Minitest::Test
     test_git = TestGit.new
     releases = PrChangelog::Releases.new(test_git)
 
-    assert_equal '0.3.0', releases.last_release
+    assert_equal '1.12.1', releases.last_release
   end
 
   def test_last_release_pair
     test_git = TestGit.new
     releases = PrChangelog::Releases.new(test_git)
 
-    assert_equal ['0.2.2', '0.3.0'], releases.last_release_pair
+    assert_equal ['1.12.0', '1.12.1'], releases.last_release_pair
   end
 
   def test_last_release_with_no_tags

--- a/test/sample_data/plain_format_squash.txt
+++ b/test/sample_data/plain_format_squash.txt
@@ -1,10 +1,10 @@
-- #499: LoginEntryView refinements
-- #500: Neighborhood profile: add collection view with cards
+- #499: Improvement: `LoginEntryView` refinements
+- #500: Improvement: neighborhood profile: add collection view with cards
 - #498: Bring colors from superview into bottom sheet
-- #497: Improve pull request template with tables
-- #496: Animate night mode transition
-- #495: Add isDefault to FavoriteFolderViewModel
-- #486: Update error and success icons
-- #493: Favorite folders: add refresh control
-- #492: Present a temporary view infront of mapview
-- #490: Feature: FavoriteAdsList
+- #497: Improvement: improve pull request template with tables
+- #496: Improvement: animate night mode transition
+- #495: Feature: add isDefault to FavoriteFolderViewModel
+- #486: Internal: update error and success icons
+- #493: Feature: favorite folders: add refresh control
+- #492: Fix: present a temporary view infront of mapview
+- #490: Feature: favoriteAdsList

--- a/test/sample_data/plain_format_squash.txt
+++ b/test/sample_data/plain_format_squash.txt
@@ -1,0 +1,8 @@
+- #499: LoginEntryView refinements
+- #500: Neighborhood profile: add collection view with cards
+- #498: Bring colors from superview into bottom sheet
+- #497: Improve pull request template with tables
+- #496: Animate night mode transition
+- #495: Add isDefault to FavoriteFolderViewModel
+- #486: Update error and success icons
+- #493: Favorite folders: add refresh control

--- a/test/sample_data/plain_format_squash.txt
+++ b/test/sample_data/plain_format_squash.txt
@@ -6,3 +6,5 @@
 - #495: Add isDefault to FavoriteFolderViewModel
 - #486: Update error and success icons
 - #493: Favorite folders: add refresh control
+- #492: Present a temporary view infront of mapview
+- #490: Feature: FavoriteAdsList

--- a/test/sample_data/pretty_format_squash.txt
+++ b/test/sample_data/pretty_format_squash.txt
@@ -1,0 +1,19 @@
+[New features]
+  - #495: ⭐️ Add isDefault to FavoriteFolderViewModel
+  - #493: ⭐️ Favorite folders: add refresh control
+  - #490: ⭐️ FavoriteAdsList
+
+[Fixes]
+  - #492: 🐛 Present a temporary view infront of mapview
+
+[Improvements]
+  - #499: 💎 `LoginEntryView` refinements
+  - #500: 💎 Neighborhood profile: add collection view with cards
+  - #497: 💎 Improve pull request template with tables
+  - #496: 💎 Animate night mode transition
+
+[Internal]
+  - #486: 👨‍💻 Update error and success icons
+
+[Unclassified]
+  - #498: ❓ Bring colors from superview into bottom sheet

--- a/test/sample_data/raw_squash_log.txt
+++ b/test/sample_data/raw_squash_log.txt
@@ -1,0 +1,118 @@
+- GitHub: LoginEntryView refinements (#499)
+  * Replace layoutMargin constraints for edge constraints + constants
+   Because the layoutMargin constraints don't work on iOS10
+
+  * Favor the `configure(for:)` method for views in `LoginEntryView`
+
+  * Add settings button to the `LoginEntryView`
+
+  * Replace LoginEntryDemoView by a view controller
+   As the login entry view will be used in the context of full screen view
+  controllers with a tabBar, I'm trying to replicate the usage as close as
+  possible to ensure testing done in FinniversKit will reflect the behavior in
+  the Finn app.
+
+  * Only show settings button in LoginEntryView if the view model says so
+
+  * Refine constraints
+
+  * Update reference image for the LoginEntryView
+
+  * Fix layout for the messaging tab
+
+  * SettingsView determines which element is the last one in the section
+   Instead of that data coming from the view model. Because the data source will
+   always know which item is the last one in the section, then it should
+  configure the cell accordingly instead of setting this through the view model
+
+
+  * Allow `SettingsViewDelegate` to set a footer view
+
+- GitHub: Neighborhood profile: add collection view with cards (#500)
+  * Add neighborhood profile view and demo view
+
+  * Add demo for neighbourhood profile view
+
+  * Setup collection view layout
+
+  * Implement header view
+
+  * Fix header view constraints
+
+  * Add snapshot tests
+
+- GitHub: Bring colors from superview into bottom sheet (#498)
+
+- GitHub: Improve pull request template with tables (#497)
+
+- GitHub: Update FinniversKit.podspec
+
+- GitHub: Animate night mode transition (#496)
+
+- GitHub: Add isDefault to FavoriteFolderViewModel (#495)
+
+- GitHub: Update error and success icons (#486)
+  * Update error and success icons
+
+  * Update icon sizes
+
+  * Update snapshot
+
+  * Add updated snapshot
+
+- GitHub: Update FinniversKit.podspec
+
+- GitHub: Favorite folders: add refresh control (#493)
+  * Add refresh control to the folders list
+
+  * Show/hide refresh control when needed
+
+- GitHub: Present a temporary view infront of mapview (#492)
+
+- GitHub: Feature: FavoriteAdsList (#490)
+  * Rename viewModel for favorite ads cell
+
+  * Add view FavoriteAdsListView
+
+  * Add headerView for tableView
+
+  * Add sortingView for tableHeader, add delegate methods
+
+  * Add demo
+
+  * Add searchBar delegate
+
+  * Pull demo viewmodel creation into helper
+
+  * Set correct font for title in tableHeader
+
+  * Set loadingColor for remoteImageView
+
+  * Formatting
+
+  * Add FavoriteAdsSectionHeaderView
+
+  * Add datasource for demo, sorting/grouping favorites
+
+  * Refactor protocol and use dataSource to populate tableView
+
+  * Set section header height to .leastNonzeroMagnitude if title is nil
+
+  * Change constraints to prevent the header from jumping when pressing search
+
+  * Filter ads based on input in searchBar
+
+  * Update delegate method signatures
+
+  * End searchBar editing on taps
+
+  * Set empty tableFooterView
+
+  * Fix swiftlint issue
+
+  * Added snapshot tests
+
+  * Rearrange placement of folders within the project
+
+  * Address PR comments
+

--- a/test/sample_data/raw_squash_log.txt
+++ b/test/sample_data/raw_squash_log.txt
@@ -1,4 +1,4 @@
-- GitHub: LoginEntryView refinements (#499)
+- GitHub Enterprise: Improvement: `LoginEntryView` refinements (#499)
   * Replace layoutMargin constraints for edge constraints + constants
    Because the layoutMargin constraints don't work on iOS10
 
@@ -28,7 +28,7 @@
 
   * Allow `SettingsViewDelegate` to set a footer view
 
-- GitHub: Neighborhood profile: add collection view with cards (#500)
+- GitHub: Improvement: Neighborhood profile: add collection view with cards (#500)
   * Add neighborhood profile view and demo view
 
   * Add demo for neighbourhood profile view
@@ -43,15 +43,15 @@
 
 - GitHub: Bring colors from superview into bottom sheet (#498)
 
-- GitHub: Improve pull request template with tables (#497)
+- GitHub: Improvement: Improve pull request template with tables (#497)
 
 - GitHub: Update FinniversKit.podspec
 
-- GitHub: Animate night mode transition (#496)
+- GitHub: Improvement: Animate night mode transition (#496)
 
-- GitHub: Add isDefault to FavoriteFolderViewModel (#495)
+- GitHub: Feature: Add isDefault to FavoriteFolderViewModel (#495)
 
-- GitHub: Update error and success icons (#486)
+- GitHub: Internal: Update error and success icons (#486)
   * Update error and success icons
 
   * Update icon sizes
@@ -62,12 +62,12 @@
 
 - GitHub: Update FinniversKit.podspec
 
-- GitHub: Favorite folders: add refresh control (#493)
+- GitHub: Feature: Favorite folders: add refresh control (#493)
   * Add refresh control to the folders list
 
   * Show/hide refresh control when needed
 
-- GitHub: Present a temporary view infront of mapview (#492)
+- GitHub: Fix: Present a temporary view infront of mapview (#492)
 
 - GitHub: Feature: FavoriteAdsList (#490)
   * Rename viewModel for favorite ads cell


### PR DESCRIPTION
Implements #17 

The idea is that not all repos use "merge commits" to merge pull requests. So for repos that
use the "squash merge" option, this changelog tool should still work as expected

## TODO

- [x] clean up implementation: i initially did a separate class to implement the other way to handle the changelog, maybe the strategy pattern can come in handy here
- [x] add support for grouped changelog for squash merges