### PR TITLE
Improvement: support dashes in PR titles and remove CI annotations

### DIFF
--- a/lib/pr_changelog/change_line.rb
+++ b/lib/pr_changelog/change_line.rb
@@ -5,10 +5,12 @@ module PrChangelog
   class ChangeLine
     attr_reader :pr_number, :tag, :title
 
+    SKIP_CI_PATTERN = /\s*\[(skip ci)\]\s*/im
+
     def initialize(pr_number, tag, title)
       @pr_number = pr_number
       @tag = tag
-      @title = title
+      @title = title.gsub(SKIP_CI_PATTERN, '')
     end
 
     def to_s

--- a/lib/pr_changelog/merge_commit_strategy.rb
+++ b/lib/pr_changelog/merge_commit_strategy.rb
@@ -17,7 +17,7 @@ module PrChangelog
 
     def parsed_commits
       merge_commits_not_merged_into_base_ref
-        .split('- ')
+        .split("\n- ")
         .reject(&:empty?)
         .map { |e| e.split("\n") }
         .select { |pair| pair.count == 2 }

--- a/test/sample_data/plain_format.txt
+++ b/test/sample_data/plain_format.txt
@@ -1,3 +1,4 @@
+- #91: Internal: ignore ci annotations
 - #86: Internal: update to android studio 3.3
 - #87: Improvement: update system notification channels from backend
 - #85: Feature: notification settings UI and sync with backend and system settings

--- a/test/sample_data/plain_format.txt
+++ b/test/sample_data/plain_format.txt
@@ -1,4 +1,5 @@
 - #91: Internal: ignore ci annotations
+- #90: Improvement: my Feature - add more info
 - #86: Internal: update to android studio 3.3
 - #87: Improvement: update system notification channels from backend
 - #85: Feature: notification settings UI and sync with backend and system settings

--- a/test/sample_data/pretty_format.txt
+++ b/test/sample_data/pretty_format.txt
@@ -12,6 +12,7 @@
   - #67: 🐛 Swipe on text in Daily Summary
 
 [Improvements]
+  - #90: 💎 My Feature - add more info
   - #87: 💎 Update system notification channels from backend
   - #84: 💎 Allow cards format to be used not only on the weekly summary
   - #80: 💎 Add app version number to the placeholder feedback email

--- a/test/sample_data/pretty_format.txt
+++ b/test/sample_data/pretty_format.txt
@@ -26,6 +26,7 @@
   - #59: 💎 Support opening external links on canvas stories
 
 [Internal]
+  - #91: 👨‍💻 Ignore ci annotations
   - #86: 👨‍💻 Update to android studio 3.3
   - #82: 👨‍💻 Fix the notification keys
   - #76: 👨‍💻 Use beta track for releasing the app

--- a/test/sample_data/raw_log.txt
+++ b/test/sample_data/raw_log.txt
@@ -1,5 +1,7 @@
 - GitHub Enterprise: Merge pull request #91 from schibsted_repo/feature/settings
   Internal: ignore ci annotations [skip ci]
+- GitHub Enterprise: Merge pull request #90 from schibsted_repo/feature/settings
+  Improvement: My Feature - add more info
 - GitHub Enterprise: Merge pull request #86 from schibsted_repo/internal/update-to-android-studio-3.3
   Internal: Update to android studio 3.3
 - GitHub Enterprise: Merge pull request #87 from schibsted_repo/feature/settings

--- a/test/sample_data/raw_log.txt
+++ b/test/sample_data/raw_log.txt
@@ -1,3 +1,5 @@
+- GitHub Enterprise: Merge pull request #91 from schibsted_repo/feature/settings
+  Internal: ignore ci annotations [skip ci]
 - GitHub Enterprise: Merge pull request #86 from schibsted_repo/internal/update-to-android-studio-3.3
   Internal: Update to android studio 3.3
 - GitHub Enterprise: Merge pull request #87 from schibsted_repo/feature/settings


### PR DESCRIPTION
There are two cases that were not supported before.

1. PR titles with `[skip ci]`

```
Internal: ignore ci annotations [skip ci]
```

2. PR titles with "-" in them

```
Improvement: My Feature - add more info
```

Both cases are handled correctly now.

1. we remove the `[skip ci]`

2. we don't discard the part of the title after `-`


I added those cases to the test we have to ensure it works, while maintaining existing functionality.

This would be a patch level change  