### PR TITLE
Internal: update development dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,23 +6,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    method_source (0.9.2)
-    minitest (5.11.3)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rake (13.0.1)
+    coderay (1.1.3)
+    method_source (1.0.0)
+    minitest (5.15.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0.1)
-  minitest (~> 5.11.3)
+  bundler (~> 2.3.9)
+  minitest (~> 5.15.0)
   pr_changelog!
-  pry (~> 0.12.2)
-  rake (~> 13.0.1)
+  pry (~> 0.14.1)
+  rake (~> 13.0.6)
 
 BUNDLED WITH
-   2.0.1
+   2.3.9

--- a/pr_changelog.gemspec
+++ b/pr_changelog.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0.1'
-  spec.add_development_dependency 'minitest', '~> 5.11.3'
-  spec.add_development_dependency 'pry', '~> 0.12.2'
-  spec.add_development_dependency 'rake', '~> 13.0.1'
+  spec.add_development_dependency 'bundler', '~> 2.3.9'
+  spec.add_development_dependency 'minitest', '~> 5.15.0'
+  spec.add_development_dependency 'pry', '~> 0.14.1'
+  spec.add_development_dependency 'rake', '~> 13.0.6'
 end


### PR DESCRIPTION
- bundler from 2.0.1 to 2.3.9
- minitest from 5.11.3 to 5.15.0
- pry from 0.12.2 to 0.14.1
- rake from 13.0.1 to 13.0.6
